### PR TITLE
refactor: 카카오 로그인 및 회원가입 전체 로직 수정 

### DIFF
--- a/src/main/java/com/leets/chikahae/domain/auth/controller/DevAuthController.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/controller/DevAuthController.java
@@ -1,70 +1,70 @@
-package com.leets.chikahae.domain.auth.controller;
-
-import com.leets.chikahae.domain.member.entity.Member;
-import com.leets.chikahae.domain.member.repository.MemberRepository;
-import com.leets.chikahae.domain.parent.repository.ParentRepository;
-import com.leets.chikahae.domain.token.service.TokenService;
-import com.leets.chikahae.global.response.ApiResponse;
-import com.leets.chikahae.security.auth.PrincipalDetails;
-import com.leets.chikahae.security.util.SecurityUtil;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDate;
-import java.util.List;
-
-@Tag(name = "Auth", description = "개발자용 로그인 API")
-@RestController
-@RequiredArgsConstructor
-public class DevAuthController {
-
-    private final ParentRepository parentRepository;
-    private final TokenService tokenService;
-    private final MemberRepository memberRepository;
-
-    @PostMapping("api/dev-login")
-    public ApiResponse<String> devLogin() {
-        Member member = Member.of(
-                1L,                                  // parentId (DB에 존재하는 값인지 확인)
-                "개발자",
-                LocalDate.of(2021, 7, 14),
-                true,
-                "https://example.com/profile.jpg"
-        );
-
-        Member savedMember = memberRepository.save(member);
-        System.out.println("Saved Member: " + savedMember);
-
-        Long memberId = savedMember.getId();
-        System.out.println("Member ID: " + memberId);
-
-        if (memberId == null) {
-            throw new RuntimeException("Member 저장 후 ID가 생성되지 않았습니다.");
-        }
-
-        var authorities = List.of(new SimpleGrantedAuthority("ROLE_MEMBER"));
-        PrincipalDetails principalDetails = PrincipalDetails.of(savedMember, authorities);
-
-        SecurityUtil.setAuthentication(principalDetails);
-
-        String accessToken = tokenService.issueAccessToken(savedMember.getId(), null, null);
-
-        return ApiResponse.ok(accessToken);
-    }
-
-
-    @GetMapping("api/protected")
-    public String protectedApi(@AuthenticationPrincipal PrincipalDetails principalDetails) {
-        if (principalDetails == null) {
-            return "인증이 필요합니다. (principalDetails is null)";
-        }
-        String nickname = principalDetails.getName();
-        Long memberId = principalDetails.getId();
-
-        return String.format("인증 성공! 사용자 ID: %d, 닉네임: %s", memberId, nickname);
-
-    }
-}
+//package com.leets.chikahae.domain.auth.controller;
+//
+//import com.leets.chikahae.domain.member.entity.Member;
+//import com.leets.chikahae.domain.member.repository.MemberRepository;
+//import com.leets.chikahae.domain.parent.repository.ParentRepository;
+//import com.leets.chikahae.domain.token.service.TokenService;
+//import com.leets.chikahae.global.response.ApiResponse;
+//import com.leets.chikahae.security.auth.PrincipalDetails;
+//import com.leets.chikahae.security.util.SecurityUtil;
+//import io.swagger.v3.oas.annotations.tags.Tag;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.security.core.annotation.AuthenticationPrincipal;
+//import org.springframework.security.core.authority.SimpleGrantedAuthority;
+//import org.springframework.web.bind.annotation.*;
+//
+//import java.time.LocalDate;
+//import java.util.List;
+//
+//@Tag(name = "Auth", description = "개발자용 로그인 API")
+//@RestController
+//@RequiredArgsConstructor
+//public class DevAuthController {
+//
+//    private final ParentRepository parentRepository;
+//    private final TokenService tokenService;
+//    private final MemberRepository memberRepository;
+//
+//    @PostMapping("api/dev-login")
+//    public ApiResponse<String> devLogin() {
+//        Member member = Member.of(
+//                1L,                                  // parentId (DB에 존재하는 값인지 확인)
+//                "개발자",
+//                LocalDate.of(2021, 7, 14),
+//                true,
+//                "https://example.com/profile.jpg"
+//        );
+//
+//        Member savedMember = memberRepository.save(member);
+//        System.out.println("Saved Member: " + savedMember);
+//
+//        Long memberId = savedMember.getId();
+//        System.out.println("Member ID: " + memberId);
+//
+//        if (memberId == null) {
+//            throw new RuntimeException("Member 저장 후 ID가 생성되지 않았습니다.");
+//        }
+//
+//        var authorities = List.of(new SimpleGrantedAuthority("ROLE_MEMBER"));
+//        PrincipalDetails principalDetails = PrincipalDetails.of(savedMember, authorities);
+//
+//        SecurityUtil.setAuthentication(principalDetails);
+//
+//        String accessToken = tokenService.issueAccessToken(savedMember.getId(), null, null);
+//
+//        return ApiResponse.ok(accessToken);
+//    }
+//
+//
+//    @GetMapping("api/protected")
+//    public String protectedApi(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+//        if (principalDetails == null) {
+//            return "인증이 필요합니다. (principalDetails is null)";
+//        }
+//        String nickname = principalDetails.getName();
+//        Long memberId = principalDetails.getId();
+//
+//        return String.format("인증 성공! 사용자 ID: %d, 닉네임: %s", memberId, nickname);
+//
+//    }
+//}

--- a/src/main/java/com/leets/chikahae/domain/auth/controller/KakaoTestController.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/controller/KakaoTestController.java
@@ -4,13 +4,28 @@ import com.leets.chikahae.domain.auth.dto.KakaoCallbackResponse;
 import com.leets.chikahae.domain.auth.dto.KakaoUserInfo;
 import com.leets.chikahae.domain.auth.util.KakaoApiClient;
 import com.leets.chikahae.domain.auth.util.KakaoTokenFetcher;
+import com.leets.chikahae.domain.member.entity.Member;
+import com.leets.chikahae.domain.member.repository.MemberRepository;
+import com.leets.chikahae.domain.member.service.MemberService;
+import com.leets.chikahae.domain.token.entity.AccountToken;
+import com.leets.chikahae.domain.token.repository.AccountTokenRepository;
+import com.leets.chikahae.domain.token.service.TokenService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.format.DateTimeFormatter;
+
+import static com.leets.chikahae.global.response.ErrorCode.FORBIDDEN;
 
 @Tag(name = "Auth", description = "카카오톡 콜백 함수")
 @RestController
@@ -21,6 +36,11 @@ public class KakaoTestController {
 
     private final KakaoTokenFetcher fetcher;
     private final KakaoApiClient kakaoApiClient;
+    private final MemberService memberService;
+    private final MemberRepository memberRepository;
+    private final TokenService tokenService;
+    private final AccountTokenRepository accountTokenRepository;
+
 
     /**
      * 인가 코드(code)를 받아 access token JSON을 반환하는 테스트용 API
@@ -29,12 +49,47 @@ public class KakaoTestController {
      */
     @GetMapping("/callback")
     public ResponseEntity<KakaoCallbackResponse> getToken(@RequestParam String code) {
+        // 1. 카카오 access token
         String token = fetcher.getAccessToken(code);
-
-        // 부모 이름 반환
+        // 2. 카카오 유저 정보
         KakaoUserInfo user = kakaoApiClient.getUserInfo(token);
-        return ResponseEntity.ok(new KakaoCallbackResponse(token, user.getKakaoAccount().getProfile().getNickname())); // 3. 토큰 + 닉네임 반환
+        String kakaoId = String.valueOf(user.getId());
+        String nickname = user.getKakaoAccount().getProfile().getNickname();
+
+        //--------------------------------------------------------------------------
+
+        // AccountToken → Member 조회
+        Member member = memberService.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원 정보 없음"));
+
+
+        //  kakaoId → AccountToken 조회
+        AccountToken accountToken = accountTokenRepository.findByMemberId(member)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "카카오 계정 없음"));
+
+
+        // 자녀의 생년월일로 만나이 판단
+        if (isUnder14(member.getBirth())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "만 14세 미만은 보호자 동의가 필요합니다.");
+        }
+
+        // 4. access/refresh 토큰 발급
+        String accessToken = tokenService.issueAccessToken(member);
+        String refreshToken = tokenService.issueRefreshToken(member);
+
+        // 5. 응답
+        return ResponseEntity.ok(new KakaoCallbackResponse(accessToken, refreshToken, nickname));
+
+
+
     }
+
+
+    // 만나이 계산 유틸 함수
+    private boolean isUnder14(LocalDate birth) {
+        return Period.between(birth, LocalDate.now()).getYears() < 14;
+    }
+
 
 
 

--- a/src/main/java/com/leets/chikahae/domain/auth/controller/KakaoTestController.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/controller/KakaoTestController.java
@@ -49,49 +49,74 @@ public class KakaoTestController {
      */
     @GetMapping("/callback")
     public ResponseEntity<KakaoCallbackResponse> getToken(@RequestParam String code) {
-        // 1. 카카오 access token
-        String token = fetcher.getAccessToken(code);
-        // 2. 카카오 유저 정보
-        KakaoUserInfo user = kakaoApiClient.getUserInfo(token);
+
+        // 1. 카카오 access token 발급
+        String kakaoAccessToken = fetcher.getAccessToken(code);
+
+        // 2. 카카오 유저 정보 조회
+        KakaoUserInfo user = kakaoApiClient.getUserInfo(kakaoAccessToken);
         String kakaoId = String.valueOf(user.getId());
         String nickname = user.getKakaoAccount().getProfile().getNickname();
 
-        //--------------------------------------------------------------------------
-
-        // AccountToken → Member 조회
+        // 3. 회원 조회
         Member member = memberService.findByKakaoId(kakaoId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원 정보 없음"));
 
+        // 4. 서비스 자체 JWT 토큰 발급
+        String serviceAccessToken = tokenService.issueAccessToken(member);
+        String serviceRefreshToken = tokenService.issueRefreshToken(member);
 
-        //  kakaoId → AccountToken 조회
-        AccountToken accountToken = accountTokenRepository.findByMemberId(member)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "카카오 계정 없음"));
-
-
-        // 자녀의 생년월일로 만나이 판단
-        if (isUnder14(member.getBirth())) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "만 14세 미만은 보호자 동의가 필요합니다.");
-        }
-
-        // 4. access/refresh 토큰 발급
-        String accessToken = tokenService.issueAccessToken(member);
-        String refreshToken = tokenService.issueRefreshToken(member);
-
-        // 5. 응답
-        return ResponseEntity.ok(new KakaoCallbackResponse(accessToken, refreshToken, nickname));
-
-
-
+        // 5. 응답 반환
+        return ResponseEntity.ok(new KakaoCallbackResponse(serviceAccessToken, serviceRefreshToken, nickname));
     }
 
-
-    // 만나이 계산 유틸 함수
-    private boolean isUnder14(LocalDate birth) {
-        return Period.between(birth, LocalDate.now()).getYears() < 14;
-    }
-
-
-
-
-
+//    @GetMapping("/callback")
+//    public ResponseEntity<KakaoCallbackResponse> getToken(@RequestParam String code) {
+//        // 1. 카카오 access token
+//        String token = fetcher.getAccessToken(code);
+//        // 2. 카카오 유저 정보
+//        KakaoUserInfo user = kakaoApiClient.getUserInfo(token);
+//        String kakaoId = String.valueOf(user.getId());
+//        String nickname = user.getKakaoAccount().getProfile().getNickname();
+//
+//
+//        //--------------------------------------------------------------------------
+//
+//        // AccountToken → Member 조회
+//        Member member = memberService.findByKakaoId(kakaoId)
+//                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원 정보 없음"));
+//
+//
+//        //  kakaoId → AccountToken 조회
+//        AccountToken accountToken = accountTokenRepository.findByMemberAndTokenType(member, "ACCESS")
+//                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "카카오 계정 없음"));
+//
+//        String serviceAccessToken = tokenService.issueAccessToken(member);
+//        String serviceRefreshToken = tokenService.issueRefreshToken(member);
+//
+//        return ResponseEntity.ok(new KakaoCallbackResponse(serviceAccessToken, serviceRefreshToken, nickname));
+//
+//
+//
+////        // 자녀의 생년월일로 만나이 판단
+////        if (isUnder14(member.getBirth())) {
+////            System.out.println("생년월일: " + member.getBirth());
+////            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "만 14세 미만은 보호자 동의가 필요합니다.");
+////        }
+//
+//        // 5. 응답
+////        return ResponseEntity.ok(new KakaoCallbackResponse(accessToken, refreshToken, nickname));
+//
+//    }
+//
+//
+////    // 만나이 계산 유틸 함수
+////    private boolean isUnder14(LocalDate birth) {
+////        return Period.between(birth, LocalDate.now()).getYears() < 14;
+////    }
+////
+////
+//
+//
+//
 }//class

--- a/src/main/java/com/leets/chikahae/domain/auth/dto/KakaoCallbackResponse.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/dto/KakaoCallbackResponse.java
@@ -12,6 +12,9 @@ public class KakaoCallbackResponse {
     @Schema(description = "카톡 accessToken", example = "123")
     private String accessToken;
 
-    @Schema(description = "부모 이름", example = "홍길동")
+    @Schema(description = "refresh token", example = "eyJhbGciOiJIUzI1NiIsInR5...")
+    private String refreshToken;
+
+    @Schema(description = "자녀 닉네임 (로그인 사용자)", example = "이지은")
     private String nickname;
 }

--- a/src/main/java/com/leets/chikahae/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/dto/LoginResponse.java
@@ -12,7 +12,7 @@ public class LoginResponse {
     @Schema(description = "회원 ID", example = "123")
     private Long memberId;
 
-    @Schema(description = "회원 닉네임", example = "초코송이엄마")
+    @Schema(description = "회원 닉네임", example = "체리마루")
     private String nickname;
 
     @Schema(description = "새로운 Access Token")

--- a/src/main/java/com/leets/chikahae/domain/auth/dto/SignupResponse.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/dto/SignupResponse.java
@@ -15,10 +15,10 @@ public class SignupResponse {
     @Schema(description = "닉네임", example = "초코송이")
     private String nickname;
 
-    @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiJ9...")
+    @Schema(description = "Access Token", example = "빌드 터미널에 있는 토큰을 사용하세요")
     private String accessToken;
 
-    @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    @Schema(description = "Refresh Token", example = "빌드 터미널에 있는 토큰을 사용하세요")
     private String refreshToken;
 
 

--- a/src/main/java/com/leets/chikahae/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/dto/TokenResponse.java
@@ -9,11 +9,11 @@ public class TokenResponse {
     @JsonProperty("access_token")
     private String accessToken;
 
-    @JsonProperty("token_type")
-    private String tokenType;
-
     @JsonProperty("refresh_token")
     private String refreshToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
 
     @JsonProperty("expires_in")
     private int expiresIn;
@@ -23,6 +23,7 @@ public class TokenResponse {
 
     @JsonProperty("refresh_token_expires_in")
     private int refreshTokenExpiresIn;
+
 
 
 

--- a/src/main/java/com/leets/chikahae/domain/auth/util/KakaoApiClient.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/util/KakaoApiClient.java
@@ -3,8 +3,10 @@ package com.leets.chikahae.domain.auth.util;
 import com.leets.chikahae.domain.auth.dto.KakaoUserInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
 @Component
@@ -13,15 +15,25 @@ public class KakaoApiClient {
     private final WebClient webClient = WebClient.create("https://kapi.kakao.com");
 
     public KakaoUserInfo getUserInfo(String accessToken) {
+        log.info("🐾 전달된 accessToken: {}", accessToken);  // 로그 추가
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new IllegalArgumentException("AccessToken이 null이거나 비어 있습니다.");
+        }
+
         try {
             return webClient.get()
                     .uri("/v2/user/me")
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .headers(httpHeaders -> httpHeaders.setBearerAuth(accessToken))  // ✅ 여기를 변경
                     .retrieve()
                     .onStatus(
                             status -> status.is4xxClientError() || status.is5xxServerError(),
                             clientResponse -> clientResponse.bodyToMono(String.class)
-                                    .map(body -> new RuntimeException("Kakao API error: " + body))
+                                    .flatMap(body -> {
+                                        log.error("❗ 카카오 API 호출 실패. 응답 바디: {}", body);
+                                        return reactor.core.publisher.Mono.error(
+                                                new ResponseStatusException(HttpStatus.UNAUTHORIZED,"카카오 API 에러:" + body)
+                                        );
+                                    })
                     )
                     .bodyToMono(KakaoUserInfo.class)
                     .block();

--- a/src/main/java/com/leets/chikahae/domain/auth/util/KakaoTokenFetcher.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/util/KakaoTokenFetcher.java
@@ -29,6 +29,15 @@ public class KakaoTokenFetcher {
                 .retrieve()
                 .bodyToMono(TokenResponse.class)
                 .block();
+
+        if (response == null || response.getAccessToken() == null) {
+            throw new RuntimeException("AccessToken 파싱 실패 (response == null 또는 토큰 없음)");
+        }
+
+        log.info("🔑 토큰 응답: {}", response);
+        log.info("✅ 카카오 Access Token 발급 완료: {}", response.getAccessToken());
+        log.info("🔍 카카오 TokenResponse: {}", response);
+        log.info("✅ 카카오 Access Token 발급 완료: {}", response.getAccessToken());
         return response.getAccessToken();
 
     }

--- a/src/main/java/com/leets/chikahae/domain/member/entity/Member.java
+++ b/src/main/java/com/leets/chikahae/domain/member/entity/Member.java
@@ -23,6 +23,9 @@ public class Member {
 	@Column(name = "parent_id")
 	private Long parentId;
 
+	@Column(name = "kakao_id", nullable = false)
+	private String kakaoId;
+
 	@Column(name = "nickname", nullable = false, unique = true)
 	private String nickname;
 

--- a/src/main/java/com/leets/chikahae/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/leets/chikahae/domain/member/repository/MemberRepository.java
@@ -13,14 +13,18 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // ✅ 닉네임 중복 확인용
     boolean existsByNickname(String nickname);
 
-    /**
-     * 부모의 카카오 ID로 회원 조회
-     */
-    @Query("SELECT m FROM Member m JOIN Parent p ON m.parentId = p.parentId WHERE p.kakaoId = :kakaoId")
-    Optional<Member> findByParentKakaoId(@Param("kakaoId") String kakaoId);
+    Optional<Member> findByKakaoId(String kakaoId);
 
-    /**
-     * 부모 ID로 첫 번째 자녀 조회 (Optional 반환)
-     */
-    Optional<Member> findFirstByParentId(Long parentId);
+//    /**
+//     * 부모의 카카오 ID로 회원 조회
+//     */
+//    @Query("SELECT m FROM Member m JOIN Parent p ON m.parentId = p.parentId WHERE p.kakaoId = :kakaoId")
+//    Optional<Member> findByParentKakaoId(@Param("kakaoId") String kakaoId);
+//
+//    /**
+//     * 부모 ID로 첫 번째 자녀 조회 (Optional 반환)
+//     */
+//    Optional<Member> findFirstByParentId(Long parentId);
+
+
 }

--- a/src/main/java/com/leets/chikahae/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/leets/chikahae/domain/member/repository/MemberRepository.java
@@ -15,16 +15,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByKakaoId(String kakaoId);
 
-//    /**
-//     * 부모의 카카오 ID로 회원 조회
-//     */
-//    @Query("SELECT m FROM Member m JOIN Parent p ON m.parentId = p.parentId WHERE p.kakaoId = :kakaoId")
-//    Optional<Member> findByParentKakaoId(@Param("kakaoId") String kakaoId);
-//
-//    /**
-//     * 부모 ID로 첫 번째 자녀 조회 (Optional 반환)
-//     */
-//    Optional<Member> findFirstByParentId(Long parentId);
-
 
 }

--- a/src/main/java/com/leets/chikahae/domain/member/service/MemberService.java
+++ b/src/main/java/com/leets/chikahae/domain/member/service/MemberService.java
@@ -6,8 +6,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.annotation.Nullable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Period;
 import java.util.Optional;
 
 @Service
@@ -17,14 +19,18 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     /**
-     * 자녀 등록
+     * 사용자 등록
+     * - 14세 미만일 경우에만 보호자(parentId 저장)
+     * -14세 이상이라면 parentId 없이 등록
      */
     @Transactional
-    public Member registerChild(Long parentId, String nickname,
+    public Member registerMember(@Nullable Long parentId, String kakaoId, String nickname,
                                 LocalDate birth, Boolean gender, String profileImage) {
+
 
         Member member = Member.builder()
                 .parentId(parentId)
+                .kakaoId(kakaoId)
                 .nickname(nickname)
                 .birth(birth)
                 .gender(gender)
@@ -38,17 +44,18 @@ public class MemberService {
     }
 
     /**
-     * 부모 ID로 첫 번째 자녀 조회
+     * 카카오 ID로 사용자 조회
      */
-    public Optional<Member> findFirstChildByParentId(Long parentId) {
-        return memberRepository.findFirstByParentId(parentId);
+    public Optional<Member> findByKakaoId(String kakaoId) {
+        return memberRepository.findByKakaoId(kakaoId);
     }
 
     /**
-     * 카카오 ID로 회원 조회
+     * 만나이 계산
      */
-    public Optional<Member> findByKakaoId(String kakaoId) {
-        return memberRepository.findByParentKakaoId(kakaoId);
+    private boolean isUnder14(LocalDate birth) {
+        return Period.between(birth, LocalDate.now()).getYears() < 14;
     }
 
-}
+
+}//class

--- a/src/main/java/com/leets/chikahae/domain/token/entity/AccountToken.java
+++ b/src/main/java/com/leets/chikahae/domain/token/entity/AccountToken.java
@@ -1,10 +1,7 @@
 package com.leets.chikahae.domain.token.entity;
 
-import jakarta.persistence.Id;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
+import com.leets.chikahae.domain.member.entity.Member;
+import jakarta.persistence.*;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,8 +23,10 @@ public class AccountToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long tokenId;
 
-    @Column(nullable = false)
-    private Long memberId;
+    //memberId → Member 객체로 변경 (연관관계 설정)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(nullable = false)
     private String tokenType;

--- a/src/main/java/com/leets/chikahae/domain/token/repository/AccountTokenRepository.java
+++ b/src/main/java/com/leets/chikahae/domain/token/repository/AccountTokenRepository.java
@@ -12,12 +12,14 @@ import java.util.Optional;
 @Repository
 public interface AccountTokenRepository extends JpaRepository<AccountToken, Long> {
 
-    // AccountTokenRepository.java
-//    @Query("SELECT a FROM AccountToken a WHERE a.member.kakaoId = :kakaoId")
-    Optional<AccountToken> findByMemberId(Member member);
+    Optional<AccountToken> findByMemberAndTokenType(Member member, String tokenType);
 
 
-    Optional<AccountToken> findByMember_KakaoId(String kakaoId); // 이건 member.kakaoId 기준
+//    Optional<AccountToken> findByMemberId(Member member);
+
+//    Optional<AccountToken> findByMember(Member member);
+
+//    Optional<AccountToken> findByMember_KakaoId(String kakaoId); // 이건 member.kakaoId 기준
 
 
 }//interface

--- a/src/main/java/com/leets/chikahae/domain/token/repository/AccountTokenRepository.java
+++ b/src/main/java/com/leets/chikahae/domain/token/repository/AccountTokenRepository.java
@@ -1,11 +1,23 @@
 package com.leets.chikahae.domain.token.repository;
 
+import com.leets.chikahae.domain.member.entity.Member;
 import com.leets.chikahae.domain.token.entity.AccountToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface AccountTokenRepository extends JpaRepository<AccountToken, Long> {
+
+    // AccountTokenRepository.java
+//    @Query("SELECT a FROM AccountToken a WHERE a.member.kakaoId = :kakaoId")
+    Optional<AccountToken> findByMemberId(Member member);
+
+
+    Optional<AccountToken> findByMember_KakaoId(String kakaoId); // 이건 member.kakaoId 기준
 
 
 }//interface

--- a/src/main/java/com/leets/chikahae/domain/token/service/TokenService.java
+++ b/src/main/java/com/leets/chikahae/domain/token/service/TokenService.java
@@ -27,6 +27,7 @@ public class TokenService {
         return issueAccessToken(member, null, null);
     }
 
+
     //IP/User-Agent 정보를 기록하며 액세스 토큰 발급
     // PrincipalDetails 없이 발급 (기존용)
     public String issueAccessToken(Member member, String ipAddress, String userAgent) {
@@ -46,8 +47,6 @@ public class TokenService {
 
     //refresh 토큰 발급 및 저장
     public String issueRefreshToken(Member member) {
-     //   String token= jwtProvider.generateRefreshToken(member);
-
         AccountToken refreshToken = AccountToken.builder()
                 .member(member)
                 .tokenType("REFRESH")

--- a/src/main/java/com/leets/chikahae/domain/token/service/TokenService.java
+++ b/src/main/java/com/leets/chikahae/domain/token/service/TokenService.java
@@ -2,6 +2,7 @@ package com.leets.chikahae.domain.token.service;
 
 
 import com.leets.chikahae.domain.auth.util.JwtProvider;
+import com.leets.chikahae.domain.member.entity.Member;
 import com.leets.chikahae.domain.token.entity.AccountToken;
 import com.leets.chikahae.domain.token.repository.AccountTokenRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,16 +22,16 @@ public class TokenService {
     /**
      * 기존 호출용: IP/UA 없이 액세스 토큰 발급
      */
-    public String issueAccessToken(Long memberId) {
+    public String issueAccessToken(Member member) {
         // null, null 을 넘겨 3-arg 메서드 재사용
-        return issueAccessToken(memberId, null, null);
+        return issueAccessToken(member, null, null);
     }
 
     //IP/User-Agent 정보를 기록하며 액세스 토큰 발급
     // PrincipalDetails 없이 발급 (기존용)
-    public String issueAccessToken(Long memberId, String ipAddress, String userAgent) {
+    public String issueAccessToken(Member member, String ipAddress, String userAgent) {
         AccountToken accessToken = AccountToken.builder()
-                .memberId(memberId)
+                .member(member)
                 .tokenType("ACCESS")
                 .ipAddress(ipAddress)
                 .userAgent(userAgent)
@@ -39,22 +40,22 @@ public class TokenService {
         accountTokenRepository.save(accessToken);
 
         // PrincipalDetails 없이 최소한의 토큰
-        return jwtProvider.generateAccessToken(memberId);
+        return jwtProvider.generateAccessToken(member.getId());
     }
 
 
     //refresh 토큰 발급 및 저장
-    public String issueRefreshToken(Long memberId) {
-        String token= jwtProvider.generateRefreshToken(memberId);
+    public String issueRefreshToken(Member member) {
+     //   String token= jwtProvider.generateRefreshToken(member);
 
         AccountToken refreshToken = AccountToken.builder()
-                .memberId(memberId)
+                .member(member)
                 .tokenType("REFRESH")
                 .expiresAt(LocalDateTime.now().plusDays(14))
                 .build();
 
         accountTokenRepository.save(refreshToken);
-        return token;
+        return jwtProvider.generateRefreshToken(member.getId());
     }
 
 

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -38,6 +38,7 @@ CREATE TABLE parent (
 CREATE TABLE member (
                         member_id BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '고유 ID',
                         parent_id BIGINT NULL COMMENT '부모 ID',
+                        kakao_id VARCHAR(50) NOT NULL COMMENT '카카오 고유 ID',
                         nickname VARCHAR(200) NOT NULL UNIQUE COMMENT '자녀 닉네임',
                         birth DATE NOT NULL COMMENT '생년월일',
                         profile_image VARCHAR(255) NULL COMMENT '프로필 이미지',
@@ -56,7 +57,7 @@ CREATE TABLE member (
 -- 토큰 테이블
 CREATE TABLE account_token (
                                token_id BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '토큰ID',
-                               member_id BIGINT NOT NULL COMMENT '회원 ID',
+                               member_id BIGINT NOT NULL COMMENT '사용자 ID',
                                token_type ENUM('ACCESS', 'REFRESH') NOT NULL DEFAULT 'ACCESS' COMMENT '토큰 유형',
                                ip_address VARCHAR(200) NULL COMMENT '보안 로그인(고려)',
                                user_agent VARCHAR(200) NULL COMMENT '기기, 브라우저 기록',


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->

### 회원가입
- 카카오 로그인 성공 후 회원가입 및 JWT 토큰 발급까지 흐름 구현
- AccountToken 저장 로직 정리 및 불필요한 중복 메서드 제거
- 만 14세 미만 보호자 동의 로직 주석 처리 (임시)

### 로그인
- 카카오 로그인 시 kakaoId 중복으로 인해 발생하던 `NonUniqueResultException` 예외 처리
- `memberRepository.findByKakaoId()` 반환 타입을 `Optional<Member>`로 수정하여 안전하게 처리
- 회원가입 로직에서 중복 가입 방지 (`kakaoId` 존재 여부 확인 후 insert)
- Swagger로 로그인 재시도 시 정상 동작 확인

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

### 회원가입
- Swagger 테스트 시 accessToken을 Authorization 헤더에 포함시켜야 인증됨
- 현재는 로그인 후 별도의 사용자 리다이렉트 처리 없음 (프론트 연동 필요)

### 로그인
- 기존 DB에 kakaoId가 중복 저장되어 있었던 문제로 500 에러 발생했었음  
→ 해당 중복 레코드는 수동 삭제하여 해결  
- 재발 방지를 위해 로직 내 방어 코드 추가함
## 회원가입 테스트 가이드 (카카오 로그인 기반)

1️⃣ 기존 회원 정보 초기화
동일한 카카오 계정으로 재가입하려면 DB에서 기존 회원 및 토큰 삭제 필요.
2️⃣ 인가 코드 발급
아래 URL 접속 → 카카오 로그인 → 주소창에서 code= 뒤 값 복사 OR 빌드에 출력된 카카오 Access Token 사용. 
response_type=code
3️⃣ Swagger로 콜백 API 호출
http://localhost:8080/swagger-ui/index.html 접속
/login/kakao/callback?code=발급받은코드 호출

4️⃣ 정상 응답 확인
accessToken, refreshToken, nickname 포함된 JSON 응답 확인
→ 회원가입 성공

5️⃣ 로그인 상태 확인
Authorization: Bearer {accessToken} 헤더로 다른 API 테스트
→ 정상 로그인 동작 확인

⚠️ 참고 사항
- 인가 코드는 1회용입니다. 테스트마다 새로 발급 필요
- Swagger에서 401 오류가 발생하면 Authorization 헤더 누락 여부 확인
- 추후 14세 미만 제한 로직이 다시 활성화될 경우, 테스트 계정 생년월일 주의
--


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
<img width="1400" height="800" alt="image" src="https://github.com/user-attachments/assets/3e7551a6-da3d-4934-8659-c2130778d31e" />

<img width="1400" height="800" alt="image" src="https://github.com/user-attachments/assets/c0800b67-b569-44d6-9714-dff8c893cea4" />

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->
 #35 
## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
