### PR TITLE
fix: 로그아웃 로직 수정 - RefreshToken 기반 무효화 처리

### DIFF
--- a/src/main/java/com/leets/chikahae/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.leets.chikahae.domain.auth.controller;
 
 import com.leets.chikahae.domain.auth.controller.spec.AuthControllerSpec;
+import com.leets.chikahae.domain.auth.dto.KakaoLogoutRequst;
 import com.leets.chikahae.domain.auth.dto.KakaoSignupRequest;
 import com.leets.chikahae.domain.auth.dto.SignupResponse;
 import com.leets.chikahae.domain.auth.service.AuthService;
@@ -91,19 +92,38 @@ public class AuthController implements AuthControllerSpec {
     @Operation(
             summary = "로그아웃",
             description = """
-        현재 사용자의 Access Token을 무효화합니다.  
-        서버 또는 클라이언트에서 저장된 토큰 삭제만 수행하며, 카카오 서버와의 연결은 유지됩니다.
+        현재 사용자의 Refresh Token을 무효화합니다.  
+        서버 DB에서 해당 Refresh Token을 삭제하며, 카카오 서버와의 연결은 유지됩니다.
 
-        요청 헤더에 아래 형식의 Access Token이 포함되어야 합니다.
-        - Authorization: Bearer {access_token}
+        요청 바디에 아래 형식의 Refresh Token이 포함되어야 합니다.
+        {
+            "refreshToken": "xxx.yyy.zzz"
+        }
         """,
             security = @SecurityRequirement(name = "JWT")
     )
     @DeleteMapping("/logout")
-    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String token) {
-        authService.logout(token);
+    public ResponseEntity<Void> logout(@RequestBody KakaoLogoutRequst request) {
+        authService.logout(request.getRefreshToken());
         return ResponseEntity.noContent().build();
     }
+
+    //    @Operation(
+    //            summary = "로그아웃",
+    //            description = """
+    //        현재 사용자의 Access Token을 무효화합니다.
+    //        서버 또는 클라이언트에서 저장된 토큰 삭제만 수행하며, 카카오 서버와의 연결은 유지됩니다.
+    //
+    //        요청 헤더에 아래 형식의 Access Token이 포함되어야 합니다.
+    //        - Authorization: Bearer {access_token}
+    //        """,
+    //            security = @SecurityRequirement(name = "JWT")
+    //    )
+    //    @DeleteMapping("/logout")
+    //    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String token) {
+    //        authService.logout(token);
+    //        return ResponseEntity.noContent().build();
+    //    }
 
 
 

--- a/src/main/java/com/leets/chikahae/domain/auth/dto/KakaoLogoutRequst.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/dto/KakaoLogoutRequst.java
@@ -1,0 +1,15 @@
+package com.leets.chikahae.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "로그아웃 요청 DTO")
+public class KakaoLogoutRequst {
+
+    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String refreshToken;
+
+}//class

--- a/src/main/java/com/leets/chikahae/domain/auth/service/AuthService.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/service/AuthService.java
@@ -129,18 +129,22 @@ public class AuthService {
     }
 
     //로그아웃
-    public void logout(String accessToken) {
-        String pureToken = accessToken.replace("Bearer ", "");
-
-        // 토큰 유효성 검사 or 파싱
-        Long memberId = tokenService.extractMemberIdFromAccessToken(pureToken);
-
-        if (memberId != null) {
-            log.info("✅ 로그아웃 요청 처리 - memberId: {}", memberId);
-        } else {
-            log.warn("🚫 유효하지 않은 토큰으로 로그아웃 시도");
-        }
+    // RefreshToken을 기준으로 DB에서 삭제
+    public void logout(String refreshToken) {
+        tokenService.logoutByRefreshToken(refreshToken);
     }
+    //    public void logout(String accessToken) {
+    //        String pureToken = accessToken.replace("Bearer ", "");
+    //
+    //        // 토큰 유효성 검사 or 파싱
+    //        Long memberId = tokenService.extractMemberIdFromAccessToken(pureToken);
+    //
+    //        if (memberId != null) {
+    //            log.info("✅ 로그아웃 요청 처리 - memberId: {}", memberId);
+    //        } else {
+    //            log.warn("🚫 유효하지 않은 토큰으로 로그아웃 시도");
+    //        }
+    //    }
 
 
 

--- a/src/main/java/com/leets/chikahae/domain/token/entity/AccountToken.java
+++ b/src/main/java/com/leets/chikahae/domain/token/entity/AccountToken.java
@@ -31,6 +31,10 @@ public class AccountToken {
     @Column(nullable = false)
     private String tokenType;
 
+    // ✅ refreshToken 저장 (ACCESS는 null 가능)
+    @Column(columnDefinition = "TEXT")
+    private String refreshToken;
+
     private String ipAddress;
     private String userAgent;
 

--- a/src/main/java/com/leets/chikahae/domain/token/repository/AccountTokenRepository.java
+++ b/src/main/java/com/leets/chikahae/domain/token/repository/AccountTokenRepository.java
@@ -14,11 +14,14 @@ public interface AccountTokenRepository extends JpaRepository<AccountToken, Long
 
     Optional<AccountToken> findByMemberAndTokenType(Member member, String tokenType);
 
-
     //회원탈퇴 (주석: 필요할 수도 있음)
-//    @Modifying
-//    @Query("DELETE FROM AccountToken t WHERE t.member.id = :memberId")
+    //    @Modifying
+    //    @Query("DELETE FROM AccountToken t WHERE t.member.id = :memberId")
     void deleteByMemberId(Long memberId);
+
+    //로그아웃
+    void deleteByRefreshToken(String refreshToken);
+
 
 
 }//interface

--- a/src/main/java/com/leets/chikahae/domain/token/service/TokenService.java
+++ b/src/main/java/com/leets/chikahae/domain/token/service/TokenService.java
@@ -53,16 +53,29 @@ public class TokenService {
 
 
     //refresh 토큰 발급 및 저장
+
     public String issueRefreshToken(Member member) {
+        // 1. refresh 토큰 문자열 생성
+        String refreshTokenString = jwtProvider.generateRefreshToken(member.getId());
+
+        // 2. refresh 토큰 DB에 저장
         AccountToken refreshToken = AccountToken.builder()
                 .member(member)
                 .tokenType("REFRESH")
+                .refreshToken(refreshTokenString)  // ✅ 여기서 전달해야 함
                 .expiresAt(LocalDateTime.now().plusDays(14))
                 .build();
 
         accountTokenRepository.save(refreshToken);
-        return jwtProvider.generateRefreshToken(member.getId());
+        return refreshTokenString;
     }
+
+    public void logoutByRefreshToken(String refreshToken) {
+        log.info("🔐 로그아웃 요청된 refreshToken: {}", refreshToken);
+        accountTokenRepository.deleteByRefreshToken(refreshToken);
+    }
+
+
 
     //회원탈퇴
     public void deleteByMemberId(Long memberId) {

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -59,6 +59,7 @@ CREATE TABLE account_token (
                                token_id BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '토큰ID',
                                member_id BIGINT NOT NULL COMMENT '사용자 ID',
                                token_type ENUM('ACCESS', 'REFRESH') NOT NULL DEFAULT 'ACCESS' COMMENT '토큰 유형',
+                               refresh_token TEXT NULL COMMENT '리프레시 토큰 원문',
                                ip_address VARCHAR(200) NULL COMMENT '보안 로그인(고려)',
                                user_agent VARCHAR(200) NULL COMMENT '기기, 브라우저 기록',
                                expires_at DATETIME NULL COMMENT '만료일',


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 기존 AccessToken 기반 로그아웃 로직 제거
- 클라이언트로부터 전달받은 RefreshToken을 기준으로 로그아웃 처리
- account_token 테이블에서 해당 refresh_token을 삭제하여 토큰 무효화
- Swagger 문서에 요청 형식 및 동작 방식 설명 추가

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- refresh_token이 DB에 저장된 경우에만 삭제 처리됨  
- 잘못된 토큰 또는 이미 삭제된 토큰이어도 204 No Content 응답 반환

## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
<img width="670" height="802" alt="image" src="https://github.com/user-attachments/assets/35e89bdc-1860-4928-a778-6fca21987290" />

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->
- Closes #45

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ x ] 로컬에서 빌드 및 테스트 완료  
- [ x ] 코드 리뷰 반영 완료  
- [ x ] 문서화 필요 여부 확인
