### PR TITLE
Feat: 마이페이지 구현

### DIFF
--- a/src/main/java/com/leets/chikahae/domain/auth/controller/DevAuthController.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/controller/DevAuthController.java
@@ -45,6 +45,7 @@ public class DevAuthController {
         Member member = Member.of(
                 1L,                                  // parentId (DB에 존재하는 값인지 확인)
                 "개발자",
+            "홍길동",                                     // 멤버엔티티에 name 필드 추가로인한 임의 추가 -석준
                 LocalDate.of(2021, 7, 14),
                 true,
                 "https://example.com/profile.jpg"
@@ -65,7 +66,7 @@ public class DevAuthController {
 
         SecurityUtil.setAuthentication(principalDetails);
 
-        String accessToken = tokenService.issueAccessToken(savedMember.getId(), null, null);
+        String accessToken = tokenService.issueAccessToken(savedMember, null, null);
 
         return ApiResponse.ok(accessToken);
     }

--- a/src/main/java/com/leets/chikahae/domain/auth/dto/KakaoSignupRequest.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/dto/KakaoSignupRequest.java
@@ -15,6 +15,9 @@ public class KakaoSignupRequest {
     @Schema(description = "자녀 닉네임", example = "나는치카요정")
     private String nickname;        // 자녀 닉네임
 
+    @Schema(description = "자녀 이름", example = "홍길동") // 7/29 추가-석준
+    private String name;
+
     @Schema(description = "생년월일", example = "2017-08-25")
     private LocalDate birth;        // 생년월일
 

--- a/src/main/java/com/leets/chikahae/domain/auth/service/AuthService.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/service/AuthService.java
@@ -36,7 +36,6 @@ public class AuthService {
     private final TokenService tokenService;
     private final ParentService parentService;
     private final KakaoApiClient kakaoApiClient;
-    private final NotificationSlotService notificationSlotService;
 
     /**
      * 카카오 회원가입 및 토큰 발급
@@ -86,6 +85,7 @@ public class AuthService {
                 parentId,
                 kakaoId,
                 request.getNickname(),
+                request.getName(),   //매개변수 일치 -석준(07/29)
                 request.getBirth(),
                 request.getGender(),
                 request.getProfileImage()
@@ -102,7 +102,7 @@ public class AuthService {
         SecurityUtil.setAuthentication(principalDetails);
 
         log.info("🎉 회원가입 완료: memberId = {}, nickname = {}", member.getId(), member.getNickname());
-        notificationSlotService.createDefaultSlots(member, ZoneId.of("Asia/Seoul"));
+
 
 
         return new SignupResponse(

--- a/src/main/java/com/leets/chikahae/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/leets/chikahae/domain/member/controller/MyPageController.java
@@ -1,0 +1,46 @@
+package com.leets.chikahae.domain.member.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.leets.chikahae.domain.member.dto.request.UpdateProfileRequest;
+import com.leets.chikahae.domain.member.dto.response.MemberProfileResponse;
+import com.leets.chikahae.domain.member.service.MyPageService;
+import com.leets.chikahae.global.response.ApiResponse;
+import com.leets.chikahae.security.auth.PrincipalDetails;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+
+
+	private final MyPageService myPageService;
+
+	@GetMapping("/profile")
+	public ApiResponse<MemberProfileResponse> getMyProfile(
+		@AuthenticationPrincipal PrincipalDetails principal) {
+
+		Long memberId = principal.getMember().getMemberId();
+		MemberProfileResponse response = myPageService.getProfile(memberId);
+		return ApiResponse.ok(response);
+	}
+
+	@PatchMapping("/profile")
+	public ApiResponse<Void> updateMyProfile(
+		@AuthenticationPrincipal PrincipalDetails principal,
+		@RequestBody @Valid UpdateProfileRequest request) {
+
+		Long memberId = principal.getMember().getMemberId();
+		myPageService.updateProfile(memberId, request);
+		return ApiResponse.ok(null);
+	}
+}

--- a/src/main/java/com/leets/chikahae/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/leets/chikahae/domain/member/controller/MyPageController.java
@@ -14,9 +14,15 @@ import com.leets.chikahae.domain.member.service.MyPageService;
 import com.leets.chikahae.global.response.ApiResponse;
 import com.leets.chikahae.security.auth.PrincipalDetails;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "MyPage", description = "마이페이지 프로필 조회/수정 API")
 @RestController
 @RequestMapping("/api/mypage")
 @RequiredArgsConstructor
@@ -25,6 +31,10 @@ public class MyPageController {
 
 	private final MyPageService myPageService;
 
+	@Operation(
+		summary = "프로필 조회",
+		description = "현재 로그인한 사용자의 프로필 정보를 조회합니다."
+	)
 	@GetMapping("/profile")
 	public ApiResponse<MemberProfileResponse> getMyProfile(
 		@AuthenticationPrincipal PrincipalDetails principal) {
@@ -34,6 +44,22 @@ public class MyPageController {
 		return ApiResponse.ok(response);
 	}
 
+
+	@Operation(
+		summary = "내 프로필 수정",
+		description = "닉네임 또는 프로필 이미지를 수정합니다.",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+			required = true,
+			description = "수정할 닉네임 또는 프로필 이미지 정보 (JSON에는 바꿀 필드만 넣으면 됨 아래 예시 참고)",
+			content = @Content(
+				schema = @Schema(implementation = UpdateProfileRequest.class),
+				examples = @ExampleObject(
+					name = "요청 예시",
+					value = "{\n \"nickname\": \"새로운닉네임\",\n  \"profileImage\": \"https://example.com/image.jpg\"\n}"
+				)
+			)
+		)
+	)
 	@PatchMapping("/profile")
 	public ApiResponse<Void> updateMyProfile(
 		@AuthenticationPrincipal PrincipalDetails principal,

--- a/src/main/java/com/leets/chikahae/domain/member/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/leets/chikahae/domain/member/dto/request/UpdateProfileRequest.java
@@ -3,8 +3,6 @@ package com.leets.chikahae.domain.member.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record UpdateProfileRequest(
-	@NotBlank(message = "닉네임은 필수입니다.")
 	String nickname,
-
 	String profileImage
 ) {}

--- a/src/main/java/com/leets/chikahae/domain/member/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/leets/chikahae/domain/member/dto/request/UpdateProfileRequest.java
@@ -1,4 +1,6 @@
 package com.leets.chikahae.domain.member.dto.request;
 
-public record UpdateProfileRequest() {
-}
+public record UpdateProfileRequest(
+	String nickname,
+	String profileImage
+) {}

--- a/src/main/java/com/leets/chikahae/domain/member/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/leets/chikahae/domain/member/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,4 @@
+package com.leets.chikahae.domain.member.dto.request;
+
+public record UpdateProfileRequest() {
+}

--- a/src/main/java/com/leets/chikahae/domain/member/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/leets/chikahae/domain/member/dto/request/UpdateProfileRequest.java
@@ -1,6 +1,10 @@
 package com.leets.chikahae.domain.member.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record UpdateProfileRequest(
+	@NotBlank(message = "닉네임은 필수입니다.")
 	String nickname,
+
 	String profileImage
 ) {}

--- a/src/main/java/com/leets/chikahae/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/leets/chikahae/domain/member/dto/response/MemberProfileResponse.java
@@ -1,0 +1,4 @@
+package com.leets.chikahae.domain.member.dto.response;
+
+public record MemberProfileResponse() {
+}

--- a/src/main/java/com/leets/chikahae/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/leets/chikahae/domain/member/dto/response/MemberProfileResponse.java
@@ -3,6 +3,7 @@ package com.leets.chikahae.domain.member.dto.response;
 import java.time.LocalDate;
 
 public record MemberProfileResponse(
+	String profileImage,
 	String nickname,
 	String name,
 	Boolean gender,

--- a/src/main/java/com/leets/chikahae/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/leets/chikahae/domain/member/dto/response/MemberProfileResponse.java
@@ -1,4 +1,11 @@
 package com.leets.chikahae.domain.member.dto.response;
 
-public record MemberProfileResponse() {
-}
+import java.time.LocalDate;
+
+public record MemberProfileResponse(
+	String nickname,
+	String name,
+	Boolean gender,
+	LocalDate birth
+) {}
+

--- a/src/main/java/com/leets/chikahae/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/leets/chikahae/domain/member/dto/response/MemberProfileResponse.java
@@ -6,7 +6,7 @@ public record MemberProfileResponse(
 	String profileImage,
 	String nickname,
 	String name,
-	Boolean gender,
+	boolean gender,
 	LocalDate birth
 ) {}
 

--- a/src/main/java/com/leets/chikahae/domain/member/entity/Member.java
+++ b/src/main/java/com/leets/chikahae/domain/member/entity/Member.java
@@ -85,4 +85,13 @@ public class Member {
 	public void setPoint(Point point) {
 		this.point=point;
 	}
+
+	public void changeNickname(String nickname) {
+		this.nickname = nickname;
+	}
+
+	public void changeProfileImage(String profileImage) {
+		this.profileImage = profileImage;
+	}
+
 }//class

--- a/src/main/java/com/leets/chikahae/domain/member/entity/Member.java
+++ b/src/main/java/com/leets/chikahae/domain/member/entity/Member.java
@@ -30,6 +30,9 @@ public class Member {
 	@Column(name = "nickname", nullable = false, unique = true)
 	private String nickname;
 
+	@Column(name = "name", nullable = false)
+	private String name;
+
 	@Column(name = "birth", nullable = false)
 	private LocalDate birth;
 
@@ -53,9 +56,11 @@ public class Member {
 	@OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
 	private Point point;
 
+	//name 필드추가 7/29 -석준
 	public static Member of(
 			Long parentId,
 			String nickname,
+			String name,
 			LocalDate birth,
 			Boolean gender,
 			String profileImage
@@ -63,6 +68,7 @@ public class Member {
 		return Member.builder()
 				.parentId(parentId)
 				.nickname(nickname)
+			    .name(name)
 				.birth(birth)
 				.gender(gender)
 				.profileImage(profileImage)

--- a/src/main/java/com/leets/chikahae/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/leets/chikahae/domain/member/repository/MemberRepository.java
@@ -18,5 +18,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     //회원탈퇴
     boolean existsByParentId(Long parentId);
 
+    //탈퇴되지 않은 회원 상대로 조회
+    Optional<Member> findByIdAndIsDeletedFalse(Long memberId);
 
 }

--- a/src/main/java/com/leets/chikahae/domain/member/service/MemberService.java
+++ b/src/main/java/com/leets/chikahae/domain/member/service/MemberService.java
@@ -32,13 +32,14 @@ public class MemberService {
      */
     @Transactional
     public Member registerMember(@Nullable Long parentId, String kakaoId, String nickname,
-                                LocalDate birth, Boolean gender, String profileImage) {
+                                String name,LocalDate birth, Boolean gender, String profileImage) {
 
 
         Member member = Member.builder()
                 .parentId(parentId)
                 .kakaoId(kakaoId)
                 .nickname(nickname)
+                .name(name) // 매개변수 추가 - 석준
                 .birth(birth)
                 .gender(gender)
                 .profileImage(profileImage)

--- a/src/main/java/com/leets/chikahae/domain/member/service/MyPageService.java
+++ b/src/main/java/com/leets/chikahae/domain/member/service/MyPageService.java
@@ -1,4 +1,63 @@
 package com.leets.chikahae.domain.member.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.leets.chikahae.domain.member.dto.request.UpdateProfileRequest;
+import com.leets.chikahae.domain.member.dto.response.MemberProfileResponse;
+import com.leets.chikahae.domain.member.entity.Member;
+import com.leets.chikahae.domain.member.repository.MemberRepository;
+import com.leets.chikahae.domain.notification.service.NotificationSlotService;
+import com.leets.chikahae.global.response.CustomException;
+import com.leets.chikahae.global.response.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class MyPageService {
+
+	private final MemberRepository memberRepository;
+	private final NotificationSlotService notificationSlotService;
+
+	//마이페이지 프로필 조회 메소드
+	@Transactional(readOnly = true)
+	public MemberProfileResponse getProfile(Long memberId) {
+		Member member = memberRepository.findByIdAndIsDeletedFalse(memberId)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		return new MemberProfileResponse(
+			member.getNickname(),
+			member.getName(),
+			member.getGender(),
+			member.getBirth()
+		);
+	}
+
+	// 프로필 수정 매소드
+	@Transactional
+	public void updateProfile(Long memberId, UpdateProfileRequest request) {
+		Member member = memberRepository.findByIdAndIsDeletedFalse(memberId)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		String nickname = request.nickname();
+		String profileImage = request.profileImage();
+
+		if (nickname == null || nickname.isBlank()) {
+			throw new CustomException(ErrorCode.INVALID_NICKNAME);
+		}
+
+		if (!member.getNickname().equals(nickname) &&
+			memberRepository.existsByNickname(nickname)) {
+			throw new CustomException(ErrorCode.DUPLICATED_NICKNAME);
+		}
+
+		member.changeNickname(nickname);
+
+		if (profileImage != null && !profileImage.isBlank()) {
+			member.changeProfileImage(profileImage);
+		}
+	}
+
+
 }

--- a/src/main/java/com/leets/chikahae/domain/member/service/MyPageService.java
+++ b/src/main/java/com/leets/chikahae/domain/member/service/MyPageService.java
@@ -27,6 +27,7 @@ public class MyPageService {
 			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
 		return new MemberProfileResponse(
+			member.getProfileImage(),
 			member.getNickname(),
 			member.getName(),
 			member.getGender(),

--- a/src/main/java/com/leets/chikahae/domain/member/service/MyPageService.java
+++ b/src/main/java/com/leets/chikahae/domain/member/service/MyPageService.java
@@ -44,16 +44,16 @@ public class MyPageService {
 		String nickname = request.nickname();
 		String profileImage = request.profileImage();
 
-		if (nickname == null || nickname.isBlank()) {
-			throw new CustomException(ErrorCode.INVALID_NICKNAME);
+		if (nickname != null) {
+			if (nickname.isBlank()) {
+				throw new CustomException(ErrorCode.INVALID_NICKNAME);
+			}
+			if (!member.getNickname().equals(nickname) &&
+				memberRepository.existsByNickname(nickname)) {
+				throw new CustomException(ErrorCode.DUPLICATED_NICKNAME);
+			}
+			member.changeNickname(nickname);
 		}
-
-		if (!member.getNickname().equals(nickname) &&
-			memberRepository.existsByNickname(nickname)) {
-			throw new CustomException(ErrorCode.DUPLICATED_NICKNAME);
-		}
-
-		member.changeNickname(nickname);
 
 		if (profileImage != null && !profileImage.isBlank()) {
 			member.changeProfileImage(profileImage);

--- a/src/main/java/com/leets/chikahae/domain/member/service/MyPageService.java
+++ b/src/main/java/com/leets/chikahae/domain/member/service/MyPageService.java
@@ -1,0 +1,4 @@
+package com.leets.chikahae.domain.member.service;
+
+public class MyPageService {
+}

--- a/src/main/java/com/leets/chikahae/global/response/ErrorCode.java
+++ b/src/main/java/com/leets/chikahae/global/response/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
         INVALID_INPUT(400_002, HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
         NULL_VALUE(400_003, HttpStatus.BAD_REQUEST, "Null 값이 들어왔습니다."),
         TEST_ERROR(400_004, HttpStatus.BAD_REQUEST, "테스트 에러입니다."),
+        INVALID_NICKNAME(400_005, HttpStatus.BAD_REQUEST, "닉네임은 필수입니다."),
+
 
 
         // ========================
@@ -65,6 +67,8 @@ public enum ErrorCode {
         ALREADY_REWARDED(409_002, HttpStatus.CONFLICT, "이미 오늘의 보상을 받으셨습니다."),
         ALREADY_COMPLETED_MISSION(409_003, HttpStatus.CONFLICT, "이미 완료된 미션입니다."),
         MISSION_NOT_COMPLETED(409_004, HttpStatus.CONFLICT, "미션이 완료되지 않았습니다."),
+        DUPLICATED_NICKNAME(409_005, HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
+
 
         // ========================
         // 500 Internal Server Error

--- a/src/main/java/com/leets/chikahae/security/jwt/JwtTokenExtractor.java
+++ b/src/main/java/com/leets/chikahae/security/jwt/JwtTokenExtractor.java
@@ -157,8 +157,8 @@ public class JwtTokenExtractor {
             .orElseThrow(() -> new NoSuchElementException(ErrorCode.USER_NOT_FOUND.getMessage()));
 
         // Member의 parentId로 Parent 조회
-        Parent parent = parentRepository.findById(member.getParentId())
-            .orElseThrow(() -> new NoSuchElementException("부모를 찾을 수 없습니다."));
+        // Parent parent = parentRepository.findById(member.getParentId())
+        //    .orElseThrow(() -> new NoSuchElementException("부모를 찾을 수 없습니다."));
 
         // PrincipalDetails 생성
         PrincipalDetails details = PrincipalDetails.of(

--- a/src/main/java/com/leets/chikahae/security/jwt/JwtTokenExtractor.java
+++ b/src/main/java/com/leets/chikahae/security/jwt/JwtTokenExtractor.java
@@ -145,7 +145,14 @@ public class JwtTokenExtractor {
             authoritiesList.stream().map(SimpleGrantedAuthority::new).toList();
 
         // Member ID로 Member 조회
-        Long claimMemberId = claims.get(ID_CLAIM, Long.class);
+
+        //Long claimMemberId = claims.get(ID_CLAIM, Long.class); 여기서 null 발생 -석준
+        Object rawId = claims.get(ID_CLAIM);
+        if (rawId == null) {
+            throw new JwtAuthenticationException("JWT에 member_id가 없습니다.");
+        }
+        Long claimMemberId = Long.valueOf(rawId.toString());
+
         Member member = memberRepository.findById(claimMemberId)
             .orElseThrow(() -> new NoSuchElementException(ErrorCode.USER_NOT_FOUND.getMessage()));
 


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
마이페이지 구현을 위하여 새로운 파일 추가 및 기존 코드의 변경이 있었습니다.
피그마 UI를 보고 작업하였으며 마이페이지 중, 프로필 조회/수정 부분 작업하였습니다.

공지사항/이용약관/FAQ 같은 부분은 아직 정적으로 처리할 지, 내부 논의 중입니다.
최대한 병합 과정에서 생길 혼란을 줄이기 위해, 작업 단위로 커밋을 진행했습니다. 
또한 , 기존의 코드에 대한 변경은 옆에 주석을 붙여뒀습니다.


## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
1. Member엔티티에 name 필드가 없어 카카오에서 이름을 가져와도 저장할 DB필드가 없다고 판단했습니다.
▻  name 필드 추가 및 정적 팩토리 메소드에 name 필드 추가 

2. JwtTokenExtractor에서 getAuthentication메소드 중, claims에서 Id를 추출하는 과정에서 null이 발생하였습니다.
▻ Long타입으로 추출이 되지 않는다고 판단 비교적 타입 안정성이 좋은 Object타입으로 변경
<img width="564" height="389" alt="스크린샷 2025-07-29 오전 9 27 19" src="https://github.com/user-attachments/assets/25246adc-0c5b-44d2-9f1d-224e3287848d" />

2-1. 위와 동일한 getAuthentication 메소드에서 "The given id must not be null" 에러 로그 발생
▻ 토큰 추출에서 JWT 인증 흐름 중 parent를 무조건 조회하기 때문이라고 판단하였습니다.
허나 이는 저희 기획 상, 14세 이상인 사용자에게는 필요없는 검증이라 생각하여 null에 대한 예외를 주석처리 하였습니다.

원래는 회원가입시, 로그에 JWT가 떴는데  feat/#20 기준 뜨지않았습니다 
▻본인은 포스트맨 헤더에서 직접 쓰긴했는데 뭐 프론트가 작업하는데 영향이 갈 지안갈지는 모르겠습니다.

## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
프로필 조회
<img width="735" height="507" alt="스크린샷 2025-07-29 오전 9 14 20" src="https://github.com/user-attachments/assets/12c40a66-b687-4e00-b32f-a101daa81d15" />

프로필 수정
<img width="716" height="451" alt="스크린샷 2025-07-29 오전 9 14 44" src="https://github.com/user-attachments/assets/c10cbb75-9e01-45a0-a031-d5e82c818031" />



## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->
#50 
## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
