### PR TITLE
Fix: 알림 시간 변경 타입 변경

### DIFF
--- a/src/main/java/com/leets/chikahae/domain/auth/controller/DevAuthController.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/controller/DevAuthController.java
@@ -45,7 +45,8 @@ public class DevAuthController {
         Member member = Member.of(
                 1L,                                  // parentId (DB에 존재하는 값인지 확인)
                 "개발자",
-            "홍길동",                                     // 멤버엔티티에 name 필드 추가로인한 임의 추가 -석준
+            "홍길동",// 멤버엔티티에 name 필드 추가로인한 임의 추가 -석준
+                "email@example.com", //임의 이메일 추가 - 석준
                 LocalDate.of(2021, 7, 14),
                 true,
                 "https://example.com/profile.jpg"

--- a/src/main/java/com/leets/chikahae/domain/auth/service/AuthService.java
+++ b/src/main/java/com/leets/chikahae/domain/auth/service/AuthService.java
@@ -79,13 +79,14 @@ public class AuthService {
             );
             parentId = parent.getId();
         }
-        
+
 
         Member member = memberService.registerMember(
                 parentId,
                 kakaoId,
                 request.getNickname(),
                 request.getName(),   //매개변수 일치 -석준(07/29)
+                email,
                 request.getBirth(),
                 request.getGender(),
                 request.getProfileImage()

--- a/src/main/java/com/leets/chikahae/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/leets/chikahae/domain/member/dto/response/MemberProfileResponse.java
@@ -6,6 +6,7 @@ public record MemberProfileResponse(
 	String profileImage,
 	String nickname,
 	String name,
+	String kakaoEmail,
 	boolean gender,
 	LocalDate birth
 ) {}

--- a/src/main/java/com/leets/chikahae/domain/member/entity/Member.java
+++ b/src/main/java/com/leets/chikahae/domain/member/entity/Member.java
@@ -33,6 +33,9 @@ public class Member {
 	@Column(name = "name", nullable = false)
 	private String name;
 
+	@Column(name = "kakao_email", length = 100)
+	private String kakaoEmail;
+
 	@Column(name = "birth", nullable = false)
 	private LocalDate birth;
 
@@ -57,10 +60,12 @@ public class Member {
 	private Point point;
 
 	//name 필드추가 7/29 -석준
+	//카카오 이메일 필드 추가 7/30 - 석준
 	public static Member of(
 			Long parentId,
 			String nickname,
 			String name,
+			String kakaoEmail,
 			LocalDate birth,
 			Boolean gender,
 			String profileImage
@@ -69,6 +74,7 @@ public class Member {
 				.parentId(parentId)
 				.nickname(nickname)
 			    .name(name)
+				.kakaoEmail(kakaoEmail)
 				.birth(birth)
 				.gender(gender)
 				.profileImage(profileImage)

--- a/src/main/java/com/leets/chikahae/domain/member/service/MemberService.java
+++ b/src/main/java/com/leets/chikahae/domain/member/service/MemberService.java
@@ -32,7 +32,7 @@ public class MemberService {
      */
     @Transactional
     public Member registerMember(@Nullable Long parentId, String kakaoId, String nickname,
-                                String name,LocalDate birth, Boolean gender, String profileImage) {
+                                String name,String email, LocalDate birth, Boolean gender, String profileImage) {
 
 
         Member member = Member.builder()
@@ -40,6 +40,7 @@ public class MemberService {
                 .kakaoId(kakaoId)
                 .nickname(nickname)
                 .name(name) // 매개변수 추가 - 석준
+                .kakaoEmail(email) // 7/30 카카오이메일추가
                 .birth(birth)
                 .gender(gender)
                 .profileImage(profileImage)

--- a/src/main/java/com/leets/chikahae/domain/member/service/MyPageService.java
+++ b/src/main/java/com/leets/chikahae/domain/member/service/MyPageService.java
@@ -30,6 +30,7 @@ public class MyPageService {
 			member.getProfileImage(),
 			member.getNickname(),
 			member.getName(),
+			member.getKakaoEmail(),
 			member.getGender(),
 			member.getBirth()
 		);

--- a/src/main/java/com/leets/chikahae/domain/notification/controller/NotificationSlotController.java
+++ b/src/main/java/com/leets/chikahae/domain/notification/controller/NotificationSlotController.java
@@ -57,7 +57,7 @@ public class NotificationSlotController {
 	/**
 	 * PATCH /api/notifications/slots/{slotType}/time
 	 * 슬롯 시간대 변경
-	 * 요청 예시: { "sendTime": "HH:mm:ss" }
+	 * 요청 예시: { "sendTime": "HH:mm" }
 	 */
 	@Operation(
 		summary     = "슬롯 시간대 변경",
@@ -70,7 +70,7 @@ public class NotificationSlotController {
 				schema    = @Schema(implementation = NotificationSlotUpdateTimeRequestDto.class),
 				examples  = @ExampleObject(
 					name  = "요청 예시",
-					value = "{\"sendTime\": \"HH:mm:ss\"}"
+					value = "{\"sendTime\": \"HH:mm\"}"
 				)
 			)
 		)

--- a/src/main/java/com/leets/chikahae/domain/notification/dto/request/NotificationSlotUpdateTimeRequestDto.java
+++ b/src/main/java/com/leets/chikahae/domain/notification/dto/request/NotificationSlotUpdateTimeRequestDto.java
@@ -3,7 +3,9 @@ package com.leets.chikahae.domain.notification.dto.request;
 
 import java.time.LocalTime;
 
-public record NotificationSlotUpdateTimeRequestDto(LocalTime sendTime) {
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public record NotificationSlotUpdateTimeRequestDto(@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")LocalTime sendTime) {
 	public static LocalTime toLocalTime(NotificationSlotUpdateTimeRequestDto req) {
 		return req.sendTime();
 	}

--- a/src/main/java/com/leets/chikahae/domain/notification/entity/NotificationSlot.java
+++ b/src/main/java/com/leets/chikahae/domain/notification/entity/NotificationSlot.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import com.leets.chikahae.domain.BaseEntity;
 
@@ -79,11 +80,13 @@ public class NotificationSlot extends BaseEntity {
 		this.sendTime = sendTime;
 		ZonedDateTime now      = Instant.now().atZone(zone);
 		LocalDateTime target   = LocalDateTime.of(now.toLocalDate(), sendTime);
-		ZonedDateTime sendDate = target.atZone(zone);
-		if ( now.isAfter(sendDate) ) {
-			sendDate = sendDate.plusDays(1);
-		}
+		ZonedDateTime sendDate = target.atZone(zone).plusDays(1);
+
 		this.nextSendAt = sendDate.toInstant();
+	}
+
+	public void scheduleNextSend() {
+		this.nextSendAt = this.nextSendAt.plus(1, ChronoUnit.DAYS);
 	}
 
 }

--- a/src/main/java/com/leets/chikahae/domain/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/leets/chikahae/domain/notification/scheduler/NotificationScheduler.java
@@ -48,7 +48,8 @@ public class NotificationScheduler {
 				// fcmPushService.sendMulticast(tokens, slot.getTitle(), slot.getMessage());
 			}
 			// 다음 전송 시각 재계산: 오늘 sendTime 기준 +1일
-			slot.changeSendTime(slot.getSendTime(), zone);
+			slot.scheduleNextSend();
+			//slot.changeSendTime(slot.getSendTime(), zone);
 		}
 	}
 }


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
위 브랜치에서는 알림 슬롯 시간 변경대에 파싱되는 형태 HH:mm:ss -> HH:mm 으로 변경하였습니다.
이는 대부분의 알림 설정 시간이 초단위 까지 이루어지지 않음을 반영하였고, 스웨거 설명란도 이에따라 수정하였습니다.

또한 알림 슬롯 시간 api 테스트를 위해 DB를 보던 중 send_time과 next_send_at이 각 시간별로 정확히 하루 뒤가 아닌 뒤죽박죽 섞여 있는 것을 확인하고  시간 계산 로직을 수정하였습니다.

이는 DB클라이언트에서  보여주는 시간대 기준이 달랐습니다 (KST / UTC) 
허나 이는 로직 상으로는 같은 시간을 의미하고 있었고 , 스케줄러가 한 번 동작하고 나면 제대로 된 표기가 됨을 알았습니다.

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

시간대 변경 요청 예시
<img width="722" height="381" alt="스크린샷 2025-07-30 오후 4 25 11" src="https://github.com/user-attachments/assets/14d69870-b73a-4e4f-8a43-98f7467b56ec" />

결과 
<img width="384" height="172" alt="스크린샷 2025-07-30 오후 4 25 18" src="https://github.com/user-attachments/assets/e27e9a5a-138d-4aac-ae1b-4f22c72a582e" />

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
