### PR TITLE
fix: 알림 푸쉬 시간 계산 로직 수정

### DIFF
--- a/src/main/java/com/leets/chikahae/domain/notification/entity/NotificationSlot.java
+++ b/src/main/java/com/leets/chikahae/domain/notification/entity/NotificationSlot.java
@@ -1,6 +1,7 @@
 package com.leets.chikahae.domain.notification.entity;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -47,7 +48,7 @@ public class NotificationSlot extends BaseEntity {
 	private LocalTime sendTime;
 
 	@Column(name = "next_send_at", nullable = false)
-	private Instant nextSendAt;  // Instant 타입 (?)
+	private LocalDateTime nextSendAt;
 
 	@Column(name = "is_enabled", nullable = false)
 	private boolean enabled;
@@ -65,28 +66,33 @@ public class NotificationSlot extends BaseEntity {
 		LocalTime sendTime, ZoneId zone, String title, String message) {
 		this.member   = member;
 		this.slotType = slotType;
+		this.sendTime  = sendTime;
 		this.title    = title;
 		this.message  = message;
 		this.enabled  = true;
-		changeSendTime(sendTime, zone);
+		computeNextSendAt();
 	}
 
 
 	public void changeEnabled(boolean enabled) {
 		this.enabled = enabled;
+		computeNextSendAt();
 	}
 
 	public void changeSendTime(LocalTime sendTime, ZoneId zone) {
 		this.sendTime = sendTime;
-		ZonedDateTime now      = Instant.now().atZone(zone);
-		LocalDateTime target   = LocalDateTime.of(now.toLocalDate(), sendTime);
-		ZonedDateTime sendDate = target.atZone(zone).plusDays(1);
+		computeNextSendAt();
 
-		this.nextSendAt = sendDate.toInstant();
+	}
+
+	private void computeNextSendAt() {
+		ZoneId zone = ZoneId.systemDefault(); // 수정: zone 인스턴스 필드 대신 로컬로 읽음
+		LocalDate tomorrow = LocalDate.now(zone).plusDays(1);
+		this.nextSendAt = LocalDateTime.of(tomorrow, this.sendTime);
 	}
 
 	public void scheduleNextSend() {
-		this.nextSendAt = this.nextSendAt.plus(1, ChronoUnit.DAYS);
+		computeNextSendAt();
 	}
 
 }

--- a/src/main/java/com/leets/chikahae/domain/notification/repository/NotificationSlotRepository.java
+++ b/src/main/java/com/leets/chikahae/domain/notification/repository/NotificationSlotRepository.java
@@ -1,6 +1,7 @@
 package com.leets.chikahae.domain.notification.repository;
 
 import java.time.Instant;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,5 +38,8 @@ public interface NotificationSlotRepository extends JpaRepository<NotificationSl
 	List<NotificationSlot> findByMember_MemberId(Long memberId);
 
 	Optional<NotificationSlot> findByMember_MemberIdAndSlotType(Long memberId, SlotType slotType);
+
+	List<NotificationSlot> findBySendTimeAndEnabled(LocalTime sendTime, boolean enabled);
 }
+
 

--- a/src/main/java/com/leets/chikahae/domain/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/leets/chikahae/domain/notification/scheduler/NotificationScheduler.java
@@ -1,7 +1,10 @@
 package com.leets.chikahae.domain.notification.scheduler;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -10,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.leets.chikahae.domain.notification.entity.NotificationSlot;
+import com.leets.chikahae.domain.notification.repository.NotificationSlotRepository;
 import com.leets.chikahae.domain.notification.service.FcmPushService;
 import com.leets.chikahae.domain.notification.service.FcmTokenService;
 import com.leets.chikahae.domain.notification.service.NotificationSlotService;
@@ -17,39 +21,45 @@ import com.leets.chikahae.domain.notification.service.NotificationSlotService;
 @Component
 public class NotificationScheduler {
 
-	private final NotificationSlotService notificationSlotService;
 	private final FcmPushService fcmPushService;
 	private final FcmTokenService fcmTokenService;
+	private final NotificationSlotRepository notificationSlotRepository;
 	private final ZoneId zone = ZoneId.systemDefault();
 
-	public NotificationScheduler(NotificationSlotService notificationSlotService, FcmPushService fcmPushService,
-		FcmTokenService fcmTokenService) {
-		this.notificationSlotService = notificationSlotService;
+	public NotificationScheduler( FcmPushService fcmPushService,
+		NotificationSlotRepository notificationSlotRepository ,FcmTokenService fcmTokenService) {
 		this.fcmPushService = fcmPushService;
+		this.notificationSlotRepository = notificationSlotRepository;
 		this.fcmTokenService = fcmTokenService;
 	}
 
-	@Scheduled(cron = "0 0/1 * * * *") // 매 분마다 실행 예시
+	@Scheduled(cron = "0 0/1 * * * *")  // 매 분 0초에 실행
 	@Transactional
-	public void runScheduler() throws Exception {
-		Instant now = Instant.now();
-		// 인스턴스 메서드 호출로 수정: findDueSlots
-		List<NotificationSlot> dueSlots = notificationSlotService.findDueSlot(now);
+	public void runScheduler() {
+		// 1) 현재 KST 시:분
+		LocalTime nowTime = LocalDateTime
+			.now(zone)
+			.truncatedTo(ChronoUnit.MINUTES)
+			.toLocalTime();
 
+		// 2) sendTime == nowTime && enabled인 슬롯만 조회
+		List<NotificationSlot> dueSlots =
+			notificationSlotRepository.findBySendTimeAndEnabled(nowTime, true);
+
+		// 3) 푸시 전송 & 다음 예약 재계산
 		for (NotificationSlot slot : dueSlots) {
-			// 토큰 조회: 인스턴스 메서드 호출 (멤버아이디까지 가져오게끔 수정 07/12)
-			List<String> tokens = fcmTokenService.getTokens(slot.getMember().getMemberId()).stream()
+			List<String> tokens = fcmTokenService
+				.getTokens(slot.getMember().getMemberId())
+				.stream()
 				.map(t -> t.getFcmToken())
-				.collect(Collectors.toList());
+				.toList();
 
 			if (!tokens.isEmpty()) {
-				// 푸시 전송: 인스턴스 메서드 호출
 				fcmPushService.sendToEach(tokens, slot.getTitle(), slot.getMessage());
-				// fcmPushService.sendMulticast(tokens, slot.getTitle(), slot.getMessage());
 			}
-			// 다음 전송 시각 재계산: 오늘 sendTime 기준 +1일
+
+			// sendTime 기반으로 내일 같은 시각으로 nextSendAt 재설정
 			slot.scheduleNextSend();
-			//slot.changeSendTime(slot.getSendTime(), zone);
 		}
 	}
 }


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
표기가 UST와 KST로 다르게 나타나,  이를 하나로 통일 (KST 기준)
또 다음 알림 전송 시각인 next_send_at을 보낸시각 기준으로 +1일로 재계산

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
로직 수정 후 , 알림관련 슬롯 조회/변경 api 이상없었습니다
## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
<img width="702" height="205" alt="스크린샷 2025-08-02 오후 5 31 25" src="https://github.com/user-attachments/assets/90c97c3f-1d55-4eb2-90b4-b40f956bcd17" />
원래는 next_send_at이 뒤죽박죽으로 떴었음
## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
